### PR TITLE
Fixing Famo.us's docs links and examples

### DIFF
--- a/demo/client/views/Flipper.html
+++ b/demo/client/views/Flipper.html
@@ -7,8 +7,8 @@
 			which currently affects the header (which is at z-Index: 100).</p>
 			<p>
 				Famous:
-				<a href="http://www.famo.us/docs/0.2.0/views/Flipper">Docs</a> |
-				<a href="http://www.famo.us/examples/0.2.0/views/flipper/example">Example</a>
+				<a href="http://www.famo.us/docs/views/Flipper">Docs</a> |
+				<a href="https://rawgit.com/Famous/famous/v0.3.0-rc/examples/views/Flipper/example.html">Example</a>
 			</p>
 		{{/Surface}}
 
@@ -61,4 +61,3 @@
 
 <template name="views_Flipper_front"><div class="full">Front</div></template>
 <template name="views_Flipper_back"><div class="full">Back</div></template>
-

--- a/demo/client/views/HeaderFooterLayout.html
+++ b/demo/client/views/HeaderFooterLayout.html
@@ -6,8 +6,8 @@
 				and the interior surface will expand to fill all the remaining space.</p>
 			<p>
 				Famous:
-				<a href="http://www.famo.us/docs/0.2.0/views/HeaderFooterLayout/">Docs</a> |
-				<a href="http://www.famo.us/examples/0.2.0/views/headerfooterlayout/example">Example</a>
+				<a href="http://www.famo.us/docs/views/HeaderFooterLayout">Docs</a> |
+				<a href="https://rawgit.com/Famous/famous/v0.3.0-rc/examples/views/HeaderFooterLayout/example.html">Example</a>
 			</p>
 		{{/Surface}}
 


### PR DESCRIPTION
Some rough edges:
- The flipper examples from current famous-0.3.0-rc does not work, there's a require.js issue. A bit late for fixing it on famo.us (already done 2 PRs on their examples today :sweat:).
- The links to the examples carries a references to the famo.us's release number. Thus, it has to be updated each time a new release appears. This should be better factorized :flushed:.
