### PR TITLE
Add fix for new Event() failure on browsers that do not support it.

### DIFF
--- a/lib/famousContext.js
+++ b/lib/famousContext.js
@@ -91,7 +91,16 @@ var famousContext = new Template('famousContext', function () {
         document.body.childElementCount == 1)) {
       initializeFamous();
       $(container).removeClass('fview-context').addClass('famous-container');
-      window.dispatchEvent(new Event('resize'));
+
+      // make sure browser or device can use the Event constructor
+      try {
+          window.dispatchEvent(new Event('resize'));
+      } catch (e) {
+          var newEvent = document.createEvent('Event');
+          newEvent.initEvent('resize', false, false);
+          window.dispatchEvent(newEvent);
+      }
+
     }
 
     var template = data.template ? Template[data.template] : this.templateContentBlock;


### PR DESCRIPTION
This is a fix mostly for IE. Famous views would fail when attempting to create the custom "resize" event. IE does not support creating new Event objects, so I added an older method for when the new one fails. I'm sure IE users would enjoy being able to use this package (as it is awesome), especially since Famous does seem to support IE11.

http://famo.us/docs/reference/pages/0.3/browser-and-device-support.html
https://developer.mozilla.org/en-US/docs/Web/API/Event/Event