### PR TITLE
Revert "Modifier can't handle true size, so let Surface handle that"

### DIFF
--- a/lib/famous-views.js
+++ b/lib/famous-views.js
@@ -224,15 +224,6 @@ optionString = function(string, key, blazeView) {
       return undefined;
     }
 
-    if (key == 'size') {
-      _.each(obj, function(size, i) {
-        if (size == 'auto') {
-          log.debug("auto is deprecated, use true");
-          obj[i] = 'true';
-        }
-      });
-    }
-
     // re-use of "key" variable from function args that's not needed anymore
     for (key in obj)
       if (obj[key] === '__undefined__')

--- a/lib/modifiers.js
+++ b/lib/modifiers.js
@@ -1,25 +1,7 @@
 FView._registerables = {};  // used in views.js too
 
 function defaultCreate(options) {
-  var original_size = [];
-  if (options.size) {
-    original_size[0] = options.size[0];
-    original_size[1] = options.size[1];
-
-    _.each(options.size, function(size, i) {
-      //Modifier can't handle true size
-      if (size == true) {
-        options.size[i] = undefined;
-      }
-    });
-  }
-  var ret = new this._modifier.constructor(options);
-  //restore original size
-  if (options.size) {
-    options.size = original_size;
-  }
-
-  return ret;
+  return new this._modifier.constructor(options);
 }
 
 /* Available in JS via `FView._registerables.Modifier` and in templates via
@@ -66,14 +48,6 @@ FView.ready(function(require) {
     create: function(options) {
       return new Modifier(_.extend({
         transform : Transform.inFront
-      }, options));
-    }
-  });
-
-  FView.registerModifier('behind', null, {
-    create: function(options) {
-      return new Modifier(_.extend({
-        transform : Transform.behind
       }, options));
     }
   });

--- a/lib/views/Surface.js
+++ b/lib/views/Surface.js
@@ -18,9 +18,7 @@ FView.ready(function(require) {
         case 'size':
           // Let our modifier control our size
           // Long term, rather specify modifierSize and surfaceSize args?
-          // Modifier can't handler true
-          if (this._modifier && this._modifier.name == 'StateModifier' &&
-              (value[0] != true && value[1] != true))
+          if (this._modifier && this._modifier.name == 'StateModifier')
             this.surface.setSize([undefined,undefined]);
           else {
             this.surface.setSize(value);
@@ -109,7 +107,7 @@ templateSurface = function (fview, view, parentView, options, tName) {
 
   var surfaceOptions = {
     content: div,
-    //size: fview.size
+    size: fview.size
   };
 
   fview.surface = fview.view;


### PR DESCRIPTION
Reverts gadicc/meteor-famous-views#214

Hey @ShawnOceanHu, I had to revert this.  My example is a `FlexLayoutController` with `size=[undefined,true]`, wrapped in a Modifier with the same size argument.  With true, the modifier is the correct size; when the `true` height is transformed to `undefined`, the FlexLayoutController gets clipped by the Modifier which is now only as tall as it's parent element.  All this is inside a Scrollview, you can see the Plugins page as an example.