### PR TITLE
allow properties to be updated on ContainerSurface

### DIFF
--- a/lib/views/ContainerSurface.js
+++ b/lib/views/ContainerSurface.js
@@ -12,6 +12,8 @@ FView.ready(function(require) {
         this.view.setClasses(value.split(" "));
       else if (key == 'perspective')
         this.view.context.setPerspective(value);
+      else if (key == 'properties')
+        this.view.setProperties(value);
     }
   });
 });


### PR DESCRIPTION
Not sure if this is a bug or not but I've found I can't reactively update the `properties` of a `ContainerSurface.` This PR should fix that. Regression tests passed without a problem.