### PR TITLE
Fix issue for destroying node

### DIFF
--- a/lib/meteorFamousView.js
+++ b/lib/meteorFamousView.js
@@ -41,10 +41,16 @@ MeteorFamousView.prototype.destroy = function(isTemplateDestroy) {
   log.debug("Destroy (start) of " + this.type + " (#" + this.id + ") from " + this._source + ": children, components");
 
   // TODO, tests
-  _.each(this.children, function(child) {
+  for (var i = this.children.length - 1; i >= 0; i--) {
+    Blaze.remove(this.children[i].blazeView);
+  };
+
+   /* This is deistroying only odd number of node like if I have 5 children(1-5) node then its only remove 1,3,5 children because of array postion auto adjust after every node delete*/
+  // _.each(this.children, function(child) {
     //child.destroy();
-    Blaze.remove(child.blazeView);
-  });
+    // Blaze.remove(child.blazeView);
+  // });
+
 
   // components
   // TODO, tests


### PR DESCRIPTION
Hi Gadicc,

Thanks for designing the grate package for meteor + famous.
While working this package I found that

> "While moving form one route to other routes (or page).  Basically your package delete root node of that page and children, sub-children and so on.But I found issue in node deleting method. That only delete odd number of child of a node.
> Let me explain by an example let suppose i have a node with 5 children, children info save in a array. So when destroy method delete child one, then all children index rearrange in array from 0 to 3. Now while deleting second child it's delete the child whose index 1(third child) and so on and all even number of child remain in DOM."

Please check it and let me know you thoughts. 
